### PR TITLE
Fix post merge bugs Jun-7-24

### DIFF
--- a/assets/background/background.collection
+++ b/assets/background/background.collection
@@ -410,7 +410,7 @@ embedded_instances {
   ""
   position {
     x: 0.0
-    y: -100.0
+    y: 0.0
     z: 0.2
   }
   rotation {

--- a/assets/background/water.script
+++ b/assets/background/water.script
@@ -1,9 +1,8 @@
 local WIDTH = math.floor(tonumber(sys.get_config("display.width")))
-local HEIGHT = math.floor(tonumber(sys.get_config("display.height")))
 
 function init(self)
 	-- No need to render water level initially - since player will be mining down
-	msg.post("#sprite", "disable")
+	msg.post(".", "disable")
 	self.rise_started = false;
 	self.size = go.get("#sprite", "size")
 end
@@ -21,7 +20,7 @@ local function start_water_rise(self, start_at_pos)
 	start_at_pos.z = -0.1
 	go.set_position(start_at_pos)
 	-- Show sprite
-	msg.post("#sprite", "enable")
+	msg.post(".", "enable")
 
 	-- Animate water all the way to the surface line. 10 is the speed of it rising might need to adjust this as needed
 	go.animate(go.get_id(), "position.y", go.PLAYBACK_ONCE_FORWARD, self.size.y * -1, go.EASING_LINEAR, 10)

--- a/main/lights/flashlight.script
+++ b/main/lights/flashlight.script
@@ -1,4 +1,6 @@
 function init(self)
+	-- flashlight off by defalt
+	msg.post(".", "disable")
 	self.player_pos = go.get_position()
 	self.enabled = false
 	self.angle = 0
@@ -6,7 +8,7 @@ end
 
 local function update_light_position(self)
 	local offset_distance = 90 
-	local offset = vmath.vector3(math.cos(self.angle) * offset_distance, math.sin(self.angle) * offset_distance, 0)
+	local offset = vmath.vector3(math.cos(self.angle) * offset_distance, math.sin(self.angle) * offset_distance, 0.1)
 	go.set_position(self.player_pos + offset)
 end
 


### PR DESCRIPTION
- Fix destroying a tile takes user to hub. This was due to disabling the sprite instead of GO since the collision object applied to go, when user collided with it they were taken to hub
- Fix light cone z-index with the ground and set it disabled by default