### PR TITLE
Fix rendering duplication in the render script

### DIFF
--- a/main/render/custom.render_script
+++ b/main/render/custom.render_script
@@ -204,6 +204,7 @@ function update(self)
 
 	render.set_view(camera_world.view)
 	render.set_projection(camera_world.proj)
+	render.clear(state.clear_buffers)
 
 	render_to_render_target(self.render_target_world, function()
 		clear_with_color(state.clear_buffers[render.BUFFER_COLOR_BIT])


### PR DESCRIPTION
This PR fixes duplication of sprite rendering behind background. Essentially clearing the buffer before new frame render.